### PR TITLE
Added option for toast with title

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ const defaults = {
   progress: 0,          // current progress
   reversed: false,      // insert new toast to bottom of stack
   intro: { x: 256 },    // toast intro fly animation settings
-  theme: {}             // css var overrides
+  theme: {},            // css var overrides
+  title: null           // insert a title for the toast (optional)
 }
 ```
 

--- a/src/SvelteToast.svelte
+++ b/src/SvelteToast.svelte
@@ -12,7 +12,8 @@ const defaults = {
   progress: 0,
   reversed: false,
   intro: { x: 256 },
-  theme: {}
+  theme: {},
+  title: null
 }
 toast._opts(defaults)
 $: toast._opts(options)

--- a/src/ToastItem.svelte
+++ b/src/ToastItem.svelte
@@ -32,8 +32,15 @@ $: if (prevProgress !== item.progress) {
   display: flex;
   flex-direction: row;
   align-items: center;
+  flex-wrap: wrap;
   will-change: transform,opacity;
   -webkit-tap-highlight-color: transparent;
+}
+._toastTitle {
+  font: var(--toastFont);
+  flex: 1 0 100%;
+  padding: 0 0.5rem;
+  font-weight: bold;
 }
 ._toastMsg {
   font: var(--toastFont);
@@ -75,6 +82,10 @@ $: if (prevProgress !== item.progress) {
 </style>
 
 <div class="_toastItem">
+  {#if item.title}
+  <div class="_toastTitle">{item.title}</div>
+  {/if}
+
   <div class="_toastMsg">{item.msg}</div>
 
   {#if item.dismissable}

--- a/src/ToastItem.svelte
+++ b/src/ToastItem.svelte
@@ -32,14 +32,10 @@ $: if (prevProgress !== item.progress) {
   display: flex;
   flex-direction: row;
   align-items: center;
-  flex-wrap: wrap;
   will-change: transform,opacity;
   -webkit-tap-highlight-color: transparent;
 }
 ._toastTitle {
-  font: var(--toastFont);
-  flex: 1 0 100%;
-  padding: 0 0.5rem;
   font-weight: bold;
 }
 ._toastMsg {
@@ -82,11 +78,12 @@ $: if (prevProgress !== item.progress) {
 </style>
 
 <div class="_toastItem">
-  {#if item.title}
-  <div class="_toastTitle">{item.title}</div>
-  {/if}
-
-  <div class="_toastMsg">{item.msg}</div>
+  <div class="_toastMsg">
+    {#if item.title}
+    <div class="_toastTitle">{item.title}</div>
+    {/if}
+    {item.msg}
+  </div>
 
   {#if item.dismissable}
   <div class="_toastBtn" role="button" tabindex="-1" on:click={() => toast.pop(item.id)}>✕</div>


### PR DESCRIPTION
I needed to push a toast that has title for the feedback error.
For example:
Title => **Invalid Credentials!**
Message => username or password is incorrect!

The title is optional and will not affect the current usage, the user can simply add a `title` option with the desired title.