### PR TITLE
Fix importing as ESM by using conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "svelte": "src/index.js",
   "module": "dist/index.mjs",
   "main": "dist/index.js",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./dist/index.mjs"
+  },
   "scripts": {
     "tailwind:watch": "chokidar 'docs/tailwind*.*' -c 'npm run tailwind:build'",
     "tailwind:build": "tailwind build docs/tailwind.css -c docs/tailwind.config.js -o docs/build/global.css",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,2 @@
-import SvelteToast from './SvelteToast.svelte'
-import { toast } from './stores'
-
-export { SvelteToast, toast }
+export { default as SvelteToast } from './SvelteToast.svelte'
+export { toast } from './stores'


### PR DESCRIPTION
First of all thanks for building this useful module. I'm experimenting a bit with sveltekit and run into some issues when trying to export my site as a static bundle. I'm getting following error:

```
> Using @sveltejs/adapter-static
> Named export 'SvelteToast' not found. The requested module '@zerodevx/svelte-toast' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@zerodevx/svelte-toast';
const {SvelteToast} = pkg;
```

Apparently the build logic could not figure out that this package contains an ESM bundle, even though it is configured using the `module` property in `package.json`. Reading up on [building hybrid (esm & cjs) node packages](https://dev.to/remshams/rolling-up-a-multi-module-system-esm-cjs-compatible-npm-library-with-typescript-and-babel-3gjg) led me to believe that your `package.json` might be missing the [conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports) config. Adding it fixed my issue. I also rewrote your index and took advantage of [`export`](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export).