### PR TITLE
Explicitly export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "tailwind:watch": "chokidar 'docs/tailwind*.*' -c 'npm run tailwind:build'",


### PR DESCRIPTION
This fixes the issue where node cannot resolve the module's package.json, triggering following warning in `rollup-plugin-svelte`:

```
[rollup-plugin-svelte] The following packages did not export their `package.json` file so we could not
check the "svelte" field. If you had difficulties importing svelte components from a package, then please
contact the author and ask them to export the package.json file.

- @zerodevx/svelte-toast
```

Tested it with Svelte and SvelteKit and it worked just fine for both.