### PR TITLE
🎨 Themes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,25 @@
+// index.d.ts
+declare module "@zerodevx/svelte-toast";
+
+import type { SvelteComponent } from "svelte";
+
+export interface SvelteToastOptions {
+  duration: number;
+  dismissable: boolean;
+  initial: number;
+  progress: number;
+  reversed: boolean;
+  intro: any;
+  theme: { [key: string]: string }
+}
+
+export class SvelteToast extends SvelteComponent {
+  options: SvelteToastOptions;
+}
+
+declare namespace toast {
+  export function push(text: string, options?: SvelteToastOptions): number;
+  export function pop(id: number): void;
+  export function set(id: number, options: SvelteToastOptions): void;
+  export function _opts(options: SvelteToastOptions): SvelteToastOptions;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { default as SvelteToast } from './SvelteToast.svelte'
 export { toast } from './stores'
+export { themes } from './themes'

--- a/src/themes.js
+++ b/src/themes.js
@@ -1,0 +1,23 @@
+export const themes = {
+  success: {
+    theme: {
+      '--toastBackground': 'rgba(166,239,184,.9)',
+      '--toastColor': 'rgba(0,0,0,.6)',
+      '--toastProgressBackground': 'rgba(120,208,148,0.9)'
+    }
+  },
+  error: {
+    theme: {
+      '--toastBackground': 'rgba(243,172,177,0.9)',
+      '--toastColor': 'rgba(0,0,0, .9)',
+      '--toastProgressBackground': 'rgba(226,102,111,0.8)'
+    }
+  },
+  warning: {
+    theme: {
+      '--toastBackground': 'rgb(243,242,172)',
+      '--toastColor': 'rgba(0,0,0, .9)',
+      '--toastProgressBackground': 'rgb(231,215,118)'
+    }
+  }
+}


### PR DESCRIPTION
Exposing the CSS variables that you have is really powerful / flexible, but it'd also be nice to be able to use some prebuilt options for some of the more common toast actions. 

Building on that idea, I exposed a `theme` object that has three theme props:
`success` - Green, success style toast theme
`error` - Red, error style toast theme
`warning` - Yellow, warning style toast theme. 

They would be entirely optional but would allow some nice easy and quick composing:
```
import { toast, themes } from '@zerodevx/svelte-toast'

const status = await fetch('sample', {foo: bar})

if (status === 'success'){
  toast.push(message, themes.success)
} else if (status === 'error') {
  toast.push(message, themes.error)
 } else {
  toast.push(message)
 }
```