### PR TITLE
adds types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "svelte": "src/index.js",
   "module": "dist/index.mjs",
   "main": "dist/index.js",
+  "types": "src/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.js",


### PR DESCRIPTION
Hi using the package I noticed this error when running `svelte-check`:

```
> svelte-app@1.0.0 validate
> svelte-check

Loading svelte-check in workspace: /
Getting Svelte diagnostics...
====================================

Hint: Could not find a declaration file for module '@zerodevx/svelte-toast'. '/node_modules/@zerodevx/svelte-toast/dist/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/zerodevx__svelte-toast` if it exists or add a new declaration (.d.ts) file containing `declare module '@zerodevx/svelte-toast';` (ts)
<script lang="ts">
  import { SvelteToast } from "@zerodevx/svelte-toast";
  import { setContext } from "svelte";
====================================
```

Looking for a fix a came up with this PR. The types field references typescript type definitions. 

Docs can be found here: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

I don't really know if this is a sound approach, but it worked for me, `svelte-check` now runs without warnings.