### PR TITLE
Add type definition to intro option

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 // index.d.ts
 import type { SvelteComponent } from 'svelte'
+import type { FlyParams } from 'svelte/types/runtime/transition/index'
 
 declare module '@zerodevx/svelte-toast'
 
@@ -15,7 +16,7 @@ declare module '@zerodevx/svelte-toast'
  *  intro: { x: 256 },    // toast intro fly animation settings
  *  theme: {}             // css var overrides
  * }
- ```
+ * ```
  */
 export interface SvelteToastOptions {
   duration: number
@@ -23,7 +24,7 @@ export interface SvelteToastOptions {
   initial: number
   progress: number
   reversed: boolean
-  intro: any
+  intro: FlyParams
   theme: { [key: string]: string }
 }
 


### PR DESCRIPTION
Added type definition to intro option

Since only the intro option was of type "any", I added a type definition. The intro option is only used for "in:fly" in svelte/transition, so you should be able to use the type definition -FlyParams defined in the Svelte package.

File location in the Svelte package where FlyParams is defined
https://github.com/sveltejs/svelte/blob/2ae79f6815b7594dca071f9d15546f1f47af6778/src/runtime/transition/index.ts#L64