### PR TITLE
Fix custom component support with Typescript

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,7 +33,7 @@ export interface SvelteToastOptions {
   intro?: FlyParams
   theme?: { [key: string]: string }
   component?: {
-    src: SvelteComponent
+    src: typeof SvelteComponent
     props?: { [key: string]: any }
     sendIdTo?: string
   }


### PR DESCRIPTION
The Typescript types don't currently work for custom components. I get the following error when trying to provide an imported component to `options.component.src`:
```Type 'typeof SvelteComponentDev' is missing the following properties from type 'SvelteComponentDev': $set, $on, $destroy, $$prop_def, and 5 more.```

Based on https://github.com/sveltejs/language-tools/issues/486, this PR uses `typeof SvelteComponent` instead of `SvelteComponent` on its own, which fixes the issue for me. 