### PR TITLE
Add status role to toast message

### DIFF
--- a/src/ToastItem.svelte
+++ b/src/ToastItem.svelte
@@ -127,7 +127,7 @@ onDestroy(() => {
 </style>
 
 <div class="_toastItem" class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume}>
-  <div class="_toastMsg" class:pe={item.component}>
+  <div role="status" class="_toastMsg" class:pe={item.component}>
     {#if item.component}
       <svelte:component this={item.component.src} {...getProps()} />
     {:else}


### PR DESCRIPTION
A small PR to make the toasts more accessible. Adds a status role to the toast item so that screen readers will announce the toast item message automatically when it appears.

If using a mac you can test by starting the VoiceOver screen reader utility with CMD + F5 ([JAWS](https://www.freedomscientific.com/products/software/jaws/) is a popular Windows screen reader).