### PR TITLE
Disable toast progress bar via prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ In general, use CSS variables - the following (self-explanatory) vars are expose
 }
 
 ._toastBar {
-  display: var(--toastBarDisplay, block);
   background: var(--toastBarBackground, rgba(33, 150, 243, 0.75));
   top: var(--toastBarTop, auto);
   right: var(--toastBarRight, auto);
@@ -392,6 +391,7 @@ const options = {
   pausable: false,      // pause progress bar tween on mouse hover
   dismissable: true,    // allow dismiss with close button
   reversed: false,      // insert new toast to bottom of stack
+  showProgress: true,   // show or hide the progress bar
   intro: { x: 256 },    // toast intro fly animation settings
   theme: {}             // css var overrides
 }

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ In general, use CSS variables - the following (self-explanatory) vars are expose
 }
 
 ._toastBar {
+  display: var(--toastBarDisplay, block);
   background: var(--toastBarBackground, rgba(33, 150, 243, 0.75));
   top: var(--toastBarTop, auto);
   right: var(--toastBarRight, auto);

--- a/docs/App.svelte
+++ b/docs/App.svelte
@@ -303,9 +303,9 @@ toast.pop(0)`,
   },
   {
     name: 'DISABLE PROGRESS BAR DISPLAY',
-    code: `toast.push('No progress bar', { hideProgressBar: true })`,
+    code: `toast.push('No progress bar', { showProgress: false })`,
     run: () => {
-      toast.push('No progress bar', { hideProgressBar: true })
+      toast.push('No progress bar', { showProgress: false })
     }
   }
 ]

--- a/docs/App.svelte
+++ b/docs/App.svelte
@@ -300,6 +300,13 @@ toast.pop(0)`,
         }
       })
     }
+  },
+  {
+    name: 'DISABLE PROGRESS BAR DISPLAY',
+    code: `toast.push('No progress bar', { hideProgressBar: true })`,
+    run: () => {
+      toast.push('No progress bar', { hideProgressBar: true })
+    }
   }
 ]
 </script>

--- a/src/ToastItem.svelte
+++ b/src/ToastItem.svelte
@@ -16,6 +16,7 @@ const autoclose = () => {
 let next = item.initial
 let prev = next
 let paused = false
+let hideProgressBar = item.hideProgressBar || false
 
 $: if (next !== item.next) {
   next = item.next
@@ -106,7 +107,7 @@ onDestroy(() => {
   height: var(--toastBarHeight, 6px);
   width: var(--toastBarWidth, 100%);
   position: absolute;
-  display: block;
+  display: var(--toastBarDisplay, block);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -126,7 +127,7 @@ onDestroy(() => {
 }
 </style>
 
-<div class="_toastItem" class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume}>
+<div class="_toastItem" class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume} style="--toastBarDisplay: {hideProgressBar ? 'none' : 'block'}">
   <div role="status" class="_toastMsg" class:pe={item.component}>
     {#if item.component}
       <svelte:component this={item.component.src} {...getProps()} />

--- a/src/ToastItem.svelte
+++ b/src/ToastItem.svelte
@@ -16,7 +16,6 @@ const autoclose = () => {
 let next = item.initial
 let prev = next
 let paused = false
-let hideProgressBar = item.hideProgressBar || false
 
 $: if (next !== item.next) {
   next = item.next
@@ -107,7 +106,7 @@ onDestroy(() => {
   height: var(--toastBarHeight, 6px);
   width: var(--toastBarWidth, 100%);
   position: absolute;
-  display: var(--toastBarDisplay, block);
+  display: block;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -127,7 +126,7 @@ onDestroy(() => {
 }
 </style>
 
-<div class="_toastItem" class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume} style="--toastBarDisplay: {hideProgressBar ? 'none' : 'block'}">
+<div class="_toastItem" class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume}>
   <div role="status" class="_toastMsg" class:pe={item.component}>
     {#if item.component}
       <svelte:component this={item.component.src} {...getProps()} />
@@ -138,5 +137,7 @@ onDestroy(() => {
   {#if item.dismissable}
     <div class="_toastBtn pe" role="button" tabindex="-1" on:click={close}>✕</div>
   {/if}
-  <progress class="_toastBar" value={$progress} />
+  {#if item.showProgress}
+    <progress class="_toastBar" value={$progress} />
+  {/if}
 </div>

--- a/src/stores.js
+++ b/src/stores.js
@@ -7,6 +7,7 @@ const defaults = {
   pausable: false,
   dismissable: true,
   reversed: false,
+  showProgress: true,
   intro: { x: 256 },
   theme: {}
 }


### PR DESCRIPTION
Sometimes you want a toast that does transition out but doesn't display the progress. This feature adds a prop, `showProgress`, which toggles the `<progress />` element in *ToastItem.svelte*. The prop defaults to `true` to match the current functionality.

I did not include the build files for clarity of the PR but I'm happy to add
them in if it helps.