### PR TITLE
individual css-classes per toast

### DIFF
--- a/src/SvelteToast.svelte
+++ b/src/SvelteToast.svelte
@@ -32,7 +32,7 @@ const getCss = (theme) => Object.keys(theme).reduce((a, c) => `${a}${c}:${theme[
 
 <ul class="_toastContainer">
   {#each items as item (item.id)}
-    <li in:fly={item.intro} out:fade animate:flip={{ duration: 200 }} style={getCss(item.theme)}>
+    <li class={item.classes.length ? item.classes.join(' ') : ''} in:fly={item.intro} out:fade animate:flip={{ duration: 200 }} style={getCss(item.theme)}>
       <ToastItem {item} />
     </li>
   {/each}

--- a/src/ToastItem.svelte
+++ b/src/ToastItem.svelte
@@ -126,7 +126,8 @@ onDestroy(() => {
 }
 </style>
 
-<div class="_toastItem" class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume}>
+<div class={item.itemCssClassList.length ? '_toastItem ' + item.itemCssClassList.join(' ') : '_toastItem'}
+     class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume}>
   <div role="status" class="_toastMsg" class:pe={item.component}>
     {#if item.component}
       <svelte:component this={item.component.src} {...getProps()} />

--- a/src/ToastItem.svelte
+++ b/src/ToastItem.svelte
@@ -126,8 +126,7 @@ onDestroy(() => {
 }
 </style>
 
-<div class={item.itemCssClassList.length ? '_toastItem ' + item.itemCssClassList.join(' ') : '_toastItem'}
-     class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume}>
+<div class="_toastItem" class:pe={item.pausable} on:mouseenter={pause} on:mouseleave={resume}>
   <div role="status" class="_toastMsg" class:pe={item.component}>
     {#if item.component}
       <svelte:component this={item.component.src} {...getProps()} />

--- a/src/stores.js
+++ b/src/stores.js
@@ -8,7 +8,8 @@ const defaults = {
   dismissable: true,
   reversed: false,
   intro: { x: 256 },
-  theme: {}
+  theme: {},
+  itemCssClassList: []
 }
 
 const createToast = () => {

--- a/src/stores.js
+++ b/src/stores.js
@@ -9,7 +9,7 @@ const defaults = {
   reversed: false,
   intro: { x: 256 },
   theme: {},
-  itemCssClassList: []
+  classes: []
 }
 
 const createToast = () => {


### PR DESCRIPTION
If you style your toats with scss with a lot of defined colors for different modes (light mode, dark mode, ...) it is a bit tedious to realize this via custom themes. 

With this option you can set individual css classes to the toast items and define the colors/theme inside your scss. 