### PR TITLE
Add feature pause on `visibilitychange` (#50)

### DIFF
--- a/cypress/e2e/test.cy.js
+++ b/cypress/e2e/test.cy.js
@@ -292,4 +292,37 @@ describe('Integration Tests', () => {
       .get('._toastBtn')
       .click()
   })
+
+  it('Toggles pause and resume on visibilitychange', () => {
+    cy.get('[data-btn=default]')
+      .click()
+      .document()
+      .then((doc) => {
+        cy.stub(doc, 'hidden').value(true)
+      })
+      .document()
+      .trigger('visibilitychange')
+      .get('._toastBar')
+      .then(($bar) => {
+        const old = parseFloat($bar.val())
+        cy.wait(500).then(() => {
+          expect(parseFloat($bar.val())).to.be.equal(old)
+        })
+      })
+      .document()
+      .then((doc) => {
+        cy.stub(doc, 'hidden').value(false)
+      })
+      .document()
+      .trigger('visibilitychange')
+      .get('._toastBar')
+      .then(($bar) => {
+        const old = parseFloat($bar.val())
+        cy.wait(500).then(() => {
+          expect(parseFloat($bar.val())).to.be.below(old)
+        })
+      })
+      .get('._toastBtn')
+      .click()
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodevx/svelte-toast",
-  "version": "0.7.3-rc.1",
+  "version": "0.7.3-rc.2",
   "description": "Simple elegant toast notifications",
   "author": "Jason Lee <jason@zerodevx.com>",
   "svelte": "src/index.js",


### PR DESCRIPTION
This uses the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) (if it's supported) to pause/resume a toast when browser tab visibility changes.