### PR TITLE
Fix: #106, expose SvelteToastOptions

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,2 +1,6 @@
 export { default as SvelteToast } from './SvelteToast.svelte'
 export { toast } from './stores.js'
+
+/**
+ * @typedef {import('./stores.js').SvelteToastOptions} SvelteToastOptions
+ */


### PR DESCRIPTION
Fixes #106

build result to be 

```ts
// index.d.ts
export { default as SvelteToast } from "./SvelteToast.svelte";
export { toast } from "./stores.js";
export type SvelteToastOptions = import('./stores.js').SvelteToastOptions;
```

usages to be
```ts
import { toast, type SvelteToastOptions } from '@zerodevx/svelte-toast';

function myOwnToast(message: string, option: SvelteToastOptions) {
  toast.push(message, option)
}
```