### PR TITLE
update default ._toastMsg style to wrap very long continuous strings

### DIFF
--- a/src/lib/ToastItem.svelte
+++ b/src/lib/ToastItem.svelte
@@ -139,6 +139,8 @@ onDestroy(() => {
   -webkit-tap-highlight-color: transparent;
 }
 ._toastMsg {
+  overflow: hidden;
+  text-overflow: ellipsis;
   padding: var(--toastMsgPadding, 0.75rem 0.5rem);
   flex: 1 1 0%;
 }


### PR DESCRIPTION
Hi,
found today that the lib isn't ok with very looooooong continuous strings. For example:
<img width="323" alt="Screenshot 2024-10-17 at 19 29 32" src="https://github.com/user-attachments/assets/8aecca64-b6da-4fff-a6cb-c92a42d04d4c">

I added a couple of CSS rules to make it looks like:
<img width="334" alt="Screenshot 2024-10-17 at 19 29 47" src="https://github.com/user-attachments/assets/54d70ca5-1656-4f2a-9d29-8af6f9f0e8ea">
